### PR TITLE
Improved visibility of white button on colorList

### DIFF
--- a/style.css
+++ b/style.css
@@ -86,6 +86,10 @@ button {
   border-radius: 50%;
 }
 
+.colorlist button[rel="#ffffff"]{
+  border: 1px solid gray;
+}
+
 /* Setup form */
 .setup {
   position: fixed;


### PR DESCRIPTION
Just added a CSS rule to improve the visibility of the white button on the colorlist, before the change the white blended with the background.

Sample screenshot:
![example screenshot](https://cloud.githubusercontent.com/assets/14254843/14210486/2ff699be-f7f7-11e5-9bce-195d51802a92.PNG)
